### PR TITLE
Dev 2 PR - Instruction Fetch Speedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,26 +4,11 @@ name: CI
 
 on:
     push:
-        branches: [main, dev-2]
+        branches: [dev-2]
     pull_request:
         branches: [main]
 
 jobs:
-    # testing:
-    #     name: Run Code Tests
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #         - uses: actions/checkout@v4
-            
-    #         - name: Enable Project Scripts
-    #           run: chmod +x ./utility.sh
-            
-    #         - name: Build Program
-    #           run: ./utility.sh build release
-            
-    #         - name: Run Tests
-    #           run: ./utility.sh test
-
     demos:
         name: Try Demo Programs
         runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "rust_demo_2"
 version = "0.1.0"
 edition = "2024"
 
+[[bin]]
+name = "loxim"
+path = "src/main.rs"
+
 [profile.release]
 opt-level = 2
 

--- a/benchmarks/node_no_jit/fib.js
+++ b/benchmarks/node_no_jit/fib.js
@@ -1,0 +1,19 @@
+const fib = (n) => {
+    if (n < 2) {
+        return 1;
+    }
+
+    return fib(n - 1) + fib(n - 2);
+};
+
+const start_time = Date.now();
+const ans = fib(29);
+const elapsed_time = Date.now() - start_time;
+
+console.log("Finished in ", elapsed_time, "ms");
+
+if (ans == 832040) {
+    process.exit(0);
+} else {
+    process.exit(1);
+}

--- a/benchmarks/python_3_x/faster_fib.py
+++ b/benchmarks/python_3_x/faster_fib.py
@@ -1,6 +1,6 @@
 """
     faster_fib.py\n
-    This is for a running time comparison against `faster_fib.loxie` upon the Conch VM. Unlike the naive fibonacci, this algorithm caches the previous two results in the arguments of successive calls to emulate iteration.
+    This is for a running time comparison of `fib.loxie` upon Loxie's VM vs. Python 3's VM. However, this algorithm caches the last two results despite being recursive.\n
 """
 
 import time

--- a/benchmarks/python_3_x/fib.py
+++ b/benchmarks/python_3_x/fib.py
@@ -1,6 +1,6 @@
 """
     fib.py\n
-    This is for a running time comparison against `fib.loxie` upon the Conch VM.\n
+    This is for a running time comparison of `fib.loxie` upon Loxie's VM vs. Python 3's VM.\n
 """
 
 import time

--- a/benchmarks/python_3_x/iter_fib.py
+++ b/benchmarks/python_3_x/iter_fib.py
@@ -1,6 +1,6 @@
 """
     iter_fib.py\n
-    This is for a running time comparison against `iter_fib.loxie` upon the Conch VM.
+    This is for a running time comparison of `fib.loxie` upon Loxie's VM vs. Python 3's VM.\n
 """
 
 import time

--- a/src/compiler/driver.rs
+++ b/src/compiler/driver.rs
@@ -5,9 +5,11 @@ use std::{
     fs
 };
 
+// NOTE: allow unused import for bytecode_printer::disassemble_program until a dump flag is added for the driver.
+#[allow(unused_imports)]
 use crate::{
     codegen::{
-        bytecode_emitter::BytecodeEmitter, /*bytecode_printer::disassemble_program,*/ ir_emitter::{IREmitter, IRResult}/*, ir_printer::print_cfg*/
+        bytecode_emitter::BytecodeEmitter, bytecode_printer::disassemble_program, ir_emitter::{IREmitter, IRResult}/*, ir_printer::print_cfg*/
     },
     frontend::{
         ast::Stmt, lexer::Lexer, parser::Parser, token::TokenType

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,17 +125,18 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    let program = program_opt.unwrap();
+    let mut program = program_opt.unwrap();
 
-    let mut engine = Engine::new(program, LOXIM_HEAP_OVERHEAD_DEFAULT, LOXIM_STACK_LIMIT);
+    // let mut engine = Engine::new(LOXIM_HEAP_OVERHEAD_DEFAULT, LOXIM_STACK_LIMIT);
+    let mut engine = Engine::new(&mut program, LOXIM_HEAP_OVERHEAD_DEFAULT, LOXIM_STACK_LIMIT);
 
     let pre_run_time = Instant::now();
-    let engine_status = engine.run(&global_natives);
-    let running_time = Instant::now() - pre_run_time;
+    // let engine_status = engine.run(&program, &global_natives);
+    let engine_status = engine.run(&program, &global_natives);
 
     println!(
-        "\x1b[1;33mFinished in {} microseconds\x1b[0m",
-        running_time.as_micros()
+        "\x1b[1;33mFinished in {} ms\x1b[0m",
+        pre_run_time.elapsed().as_millis()
     );
 
     match engine_status {

--- a/utility.sh
+++ b/utility.sh
@@ -1,7 +1,7 @@
 argc=$#
 
 usage_exit() {
-    echo "Usage: utility.sh [help | build | test | run | profile]\n\tNote: build [dev | release | profiling]\n\trun: [dev | release | profiling] [args...]\n\tprofile <program-name>"
+    echo "Usage: utility.sh [help | build | test | run | profile]\n\tNote: build [dev | release | profiling]\n\trun: [args...]\n\tprofile <program-name>"
     exit $1
 }
 

--- a/utility.sh
+++ b/utility.sh
@@ -5,8 +5,24 @@ usage_exit() {
     exit $1
 }
 
+handle_no_impl() {
+    echo "\033[1;31mThe action $1 is not implemented :(\033[0m";
+    exit 1;
+}
+
 handle_build() {
     cargo clean && cargo build --profile $1;
+}
+
+handle_profiling() {
+    has_profiling_artifact=$( find ./target/profiling );
+
+    if [[ $has_profiling_artifact -ne 0 ]]; then
+        echo "\033[1;33mProfiling build not found, rebuilding...\033[0m";
+        cargo clean && cargo build --profile profiling;
+    fi
+
+    samply record -s -- ./target/profiling/loxim $1;
 }
 
 handle_run() {
@@ -24,11 +40,10 @@ if [[ $action = "help" ]]; then
 elif [[ $action = "build" && $argc -eq 2 ]]; then
     handle_build $2;
 elif [[ $action = "profile" && $argc -eq 2 ]]; then
-    samply record -s -- ./target/profiling/rust_demo_2 $2;
+    handle_profiling $2
 elif [[ $action = "test" ]]; then
-    # cargo test;
-    echo "Not implemented :(";
-    exit 1;
+    # TODO: use `cargo test` cmd in a handle_tests function.
+    handle_no_impl $action
 elif [[ $action = "run" && $argc -ge 2 ]]; then
     handle_run "${@:2}";
 else


### PR DESCRIPTION
This PR focuses on changes that improve VM performance alongside smaller code cleanups. Most importantly, these changes help approach the side goal of outperforming Python 3 on recursion-heavy programs. Current recursive performance on a naively recursive Fibonacci program reaches at least 80% of Python speed up from roughly 67%.

Changes:
 - Refactored the VM to reference a `Program` instance and not rely on the old `fetch_instruction` logic.
 - Small refactors on shell scripts and `ci.yml`.